### PR TITLE
feat(electron): Electron 데스크톱 앱 설정 구현

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,99 @@
+import { app, BrowserWindow, ipcMain } from 'electron'
+import path from 'path'
+import fs from 'fs'
+// CommonJS handles __dirname automatically, but for TS file treated as module:
+// const __dirname = path.dirname(fileURLToPath(import.meta.url)) // (Removing this)
+
+// 데이터 저장 경로 (문서/PrimeRing)
+const DATA_DIR = path.join(app.getPath('documents'), 'PrimeRing')
+
+// 저장소 초기화
+if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true })
+}
+
+function createWindow() {
+    const mainWindow = new BrowserWindow({
+        width: 1200,
+        height: 800,
+        webPreferences: {
+            preload: path.join(__dirname, 'preload.js'),
+            nodeIntegration: false,
+            contextIsolation: true,
+        },
+    })
+
+    // 개발 환경: Vite Dev Server 주소
+    // 프로덕션: 빌드된 파일
+    const startUrl = process.env.ELECTRON_START_URL || 'http://localhost:5173'
+
+    console.log('🚀 Electron starting with URL:', startUrl)
+    console.log('ME: NODE_ENV=', process.env.NODE_ENV)
+    console.log('ME: app.isPackaged=', app.isPackaged)
+
+    const isDev = !app.isPackaged || process.env.NODE_ENV === 'development'
+
+    if (isDev) {
+        mainWindow.loadURL(startUrl).catch(e => {
+            console.error('❌ Failed to load URL:', e)
+            // Retry once after 3 seconds
+            setTimeout(() => {
+                console.log('🔄 Retrying load URL...')
+                mainWindow.loadURL(startUrl)
+            }, 3000)
+        })
+        mainWindow.webContents.openDevTools()
+    } else {
+        mainWindow.loadFile(path.join(__dirname, '../dist/index.html'))
+    }
+
+    mainWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
+        console.error('❌ Page failed to load:', errorCode, errorDescription)
+    })
+
+    mainWindow.webContents.on('dom-ready', () => {
+        console.log('✅ DOM Ready')
+    })
+}
+
+app.whenReady().then(() => {
+    createWindow()
+
+    app.on('activate', () => {
+        if (BrowserWindow.getAllWindows().length === 0) {
+            createWindow()
+        }
+    })
+})
+
+app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') {
+        app.quit()
+    }
+})
+
+// IPC Handlers
+ipcMain.handle('save-file', async (event, filename: string, content: string) => {
+    try {
+        const filePath = path.join(DATA_DIR, filename)
+        fs.writeFileSync(filePath, content, 'utf-8')
+        return { success: true }
+    } catch (error: any) {
+        console.error('File save error:', error)
+        return { success: false, error: error.message }
+    }
+})
+
+ipcMain.handle('load-file', async (event, filename: string) => {
+    try {
+        const filePath = path.join(DATA_DIR, filename)
+        if (!fs.existsSync(filePath)) {
+            return { success: true, data: null } // 파일 없으면 null 반환
+        }
+        const data = fs.readFileSync(filePath, 'utf-8')
+        return { success: true, data }
+    } catch (error: any) {
+        console.error('File load error:', error)
+        return { success: false, error: error.message }
+    }
+})

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,6 @@
+import { contextBridge, ipcRenderer } from 'electron'
+
+contextBridge.exposeInMainWorld('electron', {
+    saveData: (filename: string, data: string) => ipcRenderer.invoke('save-file', filename, data),
+    loadData: (filename: string) => ipcRenderer.invoke('load-file', filename),
+})

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -1,0 +1,10 @@
+export interface IElectronAPI {
+    saveData: (filename: string, data: string) => Promise<{ success: boolean; error?: string }>
+    loadData: (filename: string) => Promise<{ success: boolean; data: string | null; error?: string }>
+}
+
+declare global {
+    interface Window {
+        electron: IElectronAPI
+    }
+}


### PR DESCRIPTION
## 📋 개요
Electron을 통한 크로스 플랫폼 데스크톱 애플리케이션 기능을 구현했습니다.
## ✨ 주요 변경사항
### Electron 메인 프로세스
- **윈도우 관리**: BrowserWindow 생성 및 설정
- **IPC 통신**: 렌더러-메인 프로세스 간 통신 설정
- **개발/프로덕션 모드**: 환경별 다른 로딩 방식
### Preload 스크립트
- **안전한 API 노출**: contextBridge를 통한 제한적 API 접근
- **타입 안정성**: TypeScript 타입 정의
## 📁 변경된 파일
- `electron/main.ts` - Electron 메인 프로세스
- `electron/preload.ts` - Preload 스크립트
- `src/electron.d.ts` - Electron API 타입 정의
## 🖥️ 지원 플랫폼
- Windows
- macOS
- Linux
## ✅ 체크리스트
- [x] 메인 프로세스 구현
- [x] Preload 스크립트 구현
- [x] 타입 정의 추가
- [x] 개발 환경 동작 확인

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Electron main process with dev/prod loading, preload bridge, and IPC APIs to save/load files under `Documents/PrimeRing`.
> 
> - **Electron main process (`electron/main.ts`)**:
>   - Create `BrowserWindow` with isolated context and `preload` script.
>   - Dev/prod boot logic: load Vite dev server or built `index.html`; auto-retry on load failure; open devtools in dev.
>   - Initialize data directory at `Documents/PrimeRing`.
>   - IPC handlers: `save-file` and `load-file` for filesystem persistence.
> - **Preload (`electron/preload.ts`)**:
>   - Expose safe APIs `saveData` and `loadData` via `contextBridge` (invoke IPC channels).
> - **Types (`src/electron.d.ts`)**:
>   - Define `IElectronAPI` and global `window.electron` typings for the exposed APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3eb30f47be5553848c64a34f7905b35667fe8d93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->