### PR TITLE
test(utils): add comprehensive tests for cn utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:electron": "cross-env NODE_ENV=development tsc -p tsconfig.electron.json && wait-on tcp:5173 && electron .",
     "build": "tsc -b && vite build && tsc -p tsconfig.electron.json && electron-builder",
     "lint": "eslint .",
+    "test": "node --experimental-strip-types src/lib/utils.test.ts",
     "preview": "vite preview"
   },
   "main": "dist-electron/main.js",

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test'
+import { strictEqual } from 'node:assert'
+import { cn } from './utils.ts'
+
+describe('cn utility', () => {
+  it('should handle single string', () => {
+    strictEqual(cn('foo'), 'foo')
+  })
+
+  it('should handle multiple strings', () => {
+    strictEqual(cn('foo', 'bar'), 'foo bar')
+  })
+
+  it('should handle objects with truthy values', () => {
+    strictEqual(cn({ foo: true, bar: false }), 'foo')
+  })
+
+  it('should handle objects with falsy values', () => {
+    strictEqual(cn({ foo: false, bar: false }), '')
+  })
+
+  it('should handle arrays', () => {
+    strictEqual(cn(['foo', 'bar']), 'foo bar')
+  })
+
+  it('should handle nested arrays', () => {
+    strictEqual(cn(['foo', ['bar', 'baz']]), 'foo bar baz')
+  })
+
+  it('should handle mixed inputs', () => {
+    strictEqual(cn('foo', { bar: true, baz: false }, ['qux']), 'foo bar qux')
+  })
+
+  it('should handle falsy values (null, undefined, false, 0, empty string)', () => {
+    strictEqual(cn(null, false, 'bar', undefined, 0, ''), 'bar')
+  })
+})


### PR DESCRIPTION
This PR adds unit tests for the `cn` utility function.
It uses the built-in `node:test` runner to avoid adding new dev dependencies like `vitest` or `jest`, which is suitable for the current environment constraints.
The tests cover all standard `clsx` behavior as expected by the `cn` wrapper.
A `test` script was added to `package.json` utilizing `node --experimental-strip-types` (Node 22+).

---
*PR created automatically by Jules for task [14958458224907862891](https://jules.google.com/task/14958458224907862891) started by @Siul49*